### PR TITLE
doc: Recommend `cargo add` instead of wildcard version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ crate which is a submodule of this crate.
 
 ## Usage
 
-In order to include this crate in your dependencies, include it in your
-Cargo.toml as follows:
+In order to include this crate in your dependencies, use `cargo` as
+follows:
 
-```
-kcapi = "*"
+```sh
+cargo add kcapi
 ```
 
 Once this is done, you may access the various modules provided by this


### PR DESCRIPTION
This patch changes the description in README.md to advise using `cargo add kcapi` instead of the wildcard version which may be problematic when working with future incompatible versions.

Fixes https://github.com/puru1761/kcapi/issues/1