### PR TITLE
Make README badges link to their respective pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # KCAPI - The Official High-level Rust Bindings for libkcapi
 
-![CI Badge](https://github.com/puru1761/kcapi/actions/workflows/main.yml/badge.svg)
-![License](https://img.shields.io/github/license/puru1761/kcapi)
-![Crate Badge](https://img.shields.io/crates/v/kcapi.svg)
+[![CI Badge](https://github.com/puru1761/kcapi/actions/workflows/main.yml/badge.svg)](https://github.com/puru1761/kcapi/actions/workflows/main.yml)
+[![License](https://img.shields.io/github/license/puru1761/kcapi)](https://github.com/puru1761/kcapi/blob/master/LICENSE)
+[![Crate Badge](https://img.shields.io/crates/v/kcapi.svg)](https://crates.io/crates/kcapi)
 
 This repository contains the rust sources for the official high-level rust
 bindings for `libkcapi` - A userspace interface to the Linux Kernel's


### PR DESCRIPTION
This patch makes the badges link to:

  - CI badge to CI results page
  - license badge to the license file on GitHub
  - crate badge to the crate page on crates.io

Fixes https://github.com/puru1761/kcapi/issues/2

I've tested the resulting markdown on https://dillinger.io/

Further I suggest making the repository link (in https://github.com/puru1761/kcapi cog-wheel near About) link to https://crates.io/crates/kcapi for easier discovery.