### PR TITLE
Implement `std::error::Error` for `KcapiError`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,8 @@ impl fmt::Display for KcapiError {
     }
 }
 
+impl std::error::Error for KcapiError {}
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 struct kcapi_handle {


### PR DESCRIPTION
`KcapiError` already implemented traits required by the `Error` trait: Display and Debug.

This patch adds impl block for `std::error::Error` so that this type is more widely usable.