### PR TITLE
Allow slices as well as vectors in various functions

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -946,11 +946,15 @@ impl VMSplice for KcapiAEAD {
 ///
 /// ```
 /// let nonce = vec![0x41u8; 10];
+/// let iv = kcapi::aead::ccm_nonce_to_iv(&nonce)
+///     .expect("Failed to convert AES-CCM nonce to IV");
+///
 /// let iv = kcapi::aead::ccm_nonce_to_iv(nonce)
 ///     .expect("Failed to convert AES-CCM nonce to IV");
 /// ```
 ///
-pub fn ccm_nonce_to_iv(nonce: Vec<u8>) -> KcapiResult<Vec<u8>> {
+pub fn ccm_nonce_to_iv(nonce: impl AsRef<[u8]>) -> KcapiResult<Vec<u8>> {
+    let nonce = nonce.as_ref();
     if nonce.len() > (AES_BLOCKSIZE - 2) {
         return Err(KcapiError {
             code: -libc::EINVAL,
@@ -966,7 +970,7 @@ pub fn ccm_nonce_to_iv(nonce: Vec<u8>) -> KcapiResult<Vec<u8>> {
         .expect("Failed to convert usize into u8");
 
     let mut iv = vec![0u8; AES_BLOCKSIZE];
-    iv[1..1 + nonce.len()].clone_from_slice(nonce.as_slice());
+    iv[1..1 + nonce.len()].clone_from_slice(nonce);
     iv[0] = padlen;
 
     Ok(iv)

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -218,13 +218,17 @@ impl KcapiKDF {
     ///     .expect("Failed to set key for CTR KDF");
     ///
     /// let inp = vec![0x01u8; 16];
+    /// let out = kdf.ctr_kdf(&inp, 16)
+    ///     .expect("Failed to perform CTR KDF");
+    ///
     /// let out = kdf.ctr_kdf(inp, 16)
     ///     .expect("Failed to perform CTR KDF");
     ///
     /// assert_eq!(out.len(), 16);
     /// ```
     ///
-    pub fn ctr_kdf(&self, input: Vec<u8>, outsize: usize) -> KcapiResult<Vec<u8>> {
+    pub fn ctr_kdf(&self, input: impl AsRef<[u8]>, outsize: usize) -> KcapiResult<Vec<u8>> {
+        let input = input.as_ref();
         let mut out = vec![0u8; outsize];
         unsafe {
             let ret = kcapi_sys::kcapi_kdf_ctr(
@@ -273,13 +277,17 @@ impl KcapiKDF {
     ///     .expect("Failed to set key for DPI KDF");
     ///
     /// let inp = vec![0x01u8; 16];
+    /// let out = kdf.dpi_kdf(&inp, 16)
+    ///     .expect("Failed to perform DPI KDF");
+    ///
     /// let out = kdf.dpi_kdf(inp, 16)
     ///     .expect("Failed to perform DPI KDF");
     ///
     /// assert_eq!(out.len(), 16);
     /// ```
     ///
-    pub fn dpi_kdf(&self, input: Vec<u8>, outsize: usize) -> KcapiResult<Vec<u8>> {
+    pub fn dpi_kdf(&self, input: impl AsRef<[u8]>, outsize: usize) -> KcapiResult<Vec<u8>> {
+        let input = input.as_ref();
         let mut out = vec![0u8; outsize];
         unsafe {
             let ret = kcapi_sys::kcapi_kdf_dpi(
@@ -335,13 +343,17 @@ impl KcapiKDF {
     ///     .expect("Failed to set key for FB KDF");
     ///
     /// let inp = vec![0x00u8; 20];
+    /// let out = kdf.fb_kdf(&inp, 16)
+    ///     .expect("Failed to perform FB KDF");
+    ///
     /// let out = kdf.fb_kdf(inp, 16)
     ///     .expect("Failed to perform FB KDF");
     ///
     /// assert_eq!(out.len(), 16);
     /// ```
     ///
-    pub fn fb_kdf(&self, input: Vec<u8>, outsize: usize) -> KcapiResult<Vec<u8>> {
+    pub fn fb_kdf(&self, input: impl AsRef<[u8]>, outsize: usize) -> KcapiResult<Vec<u8>> {
+        let input = input.as_ref();
         if input.len() < self.digestsize {
             return Err(KcapiError {
                 code: -libc::EINVAL,
@@ -408,6 +420,9 @@ impl Drop for KcapiKDF {
 /// let info = vec![0u8; 16];
 /// let outsize: usize = 32;
 ///
+/// let key = kcapi::kdf::hkdf("hmac(sha1)", &ikm, &salt, &info, outsize)
+///     .expect("Failed to perform HKDF");
+///
 /// let key = kcapi::kdf::hkdf("hmac(sha1)", ikm, salt, info, outsize)
 ///     .expect("Failed to perform HKDF");
 ///
@@ -415,11 +430,14 @@ impl Drop for KcapiKDF {
 /// ```
 pub fn hkdf(
     hashname: &str,
-    ikm: Vec<u8>,
-    salt: Vec<u8>,
-    info: Vec<u8>,
+    ikm: impl AsRef<[u8]>,
+    salt: impl AsRef<[u8]>,
+    info: impl AsRef<[u8]>,
     outsize: usize,
 ) -> KcapiResult<Vec<u8>> {
+    let ikm = ikm.as_ref();
+    let salt = salt.as_ref();
+    let info = info.as_ref();
     let mut out = vec![0u8; outsize];
     if ikm.is_empty() {
         return Err(KcapiError {
@@ -477,17 +495,22 @@ pub fn hkdf(
 /// let iterations = 32;
 /// let outsize = 32;
 ///
+/// let key = kcapi::kdf::pbkdf("hmac(sha256)", &password, &salt, iterations, outsize)
+///     .expect("Failed to perform PBKDF");
+///
 /// let key = kcapi::kdf::pbkdf("hmac(sha256)", password, salt, iterations, outsize)
 ///     .expect("Failed to perform PBKDF");
 /// ```
 ///
 pub fn pbkdf(
     hashname: &str,
-    password: Vec<u8>,
-    salt: Vec<u8>,
+    password: impl AsRef<[u8]>,
+    salt: impl AsRef<[u8]>,
     iterations: u32,
     outsize: usize,
 ) -> KcapiResult<Vec<u8>> {
+    let password = password.as_ref();
+    let salt = salt.as_ref();
     let mut out = vec![0u8; outsize];
     if password.is_empty() || salt.is_empty() {
         return Err(KcapiError {

--- a/src/md.rs
+++ b/src/md.rs
@@ -202,8 +202,13 @@ impl KcapiHash {
     ///
     /// hash.update("Hello, World".as_bytes().to_vec())
     ///     .expect("Failed to update hash with input buffer");
+    ///
+    /// let slice: &[u8] = "Goodbye, World".as_bytes();
+    /// hash.update(slice)
+    ///     .expect("Failed to update hash with input buffer");
     /// ```
-    pub fn update(&self, buffer: Vec<u8>) -> KcapiResult<()> {
+    pub fn update(&self, buffer: impl AsRef<[u8]>) -> KcapiResult<()> {
+        let buffer = buffer.as_ref();
         unsafe {
             let ret = kcapi_sys::kcapi_md_update(
                 self.handle,
@@ -335,9 +340,13 @@ impl KcapiHash {
     ///
     /// let digest = hash.digest("Hello, World!".as_bytes().to_vec())
     ///     .expect("Failed to calculate message digest");
+    ///
+    /// let digest = hash.digest("Hello, World!".as_bytes())
+    ///     .expect("Failed to calculate message digest");
     /// ```
     ///
-    pub fn digest(&self, input: Vec<u8>) -> KcapiResult<Vec<u8>> {
+    pub fn digest(&self, input: impl AsRef<[u8]>) -> KcapiResult<Vec<u8>> {
+        let input = input.as_ref();
         if self.digestsize == 0 {
             return Err(KcapiError {
                 code: -libc::EINVAL,
@@ -396,9 +405,12 @@ impl Drop for KcapiHash {
 /// ```
 /// let digest = kcapi::md::digest("sha1", "Hello, World!".as_bytes().to_vec())
 ///     .expect("Failed to calculate message digest");
+///
+/// let digest = kcapi::md::digest("sha1", "Hello, World!".as_bytes())
+///     .expect("Failed to calculate message digest");
 /// ```
 ///
-pub fn digest(alg: &str, input: Vec<u8>) -> KcapiResult<Vec<u8>> {
+pub fn digest(alg: &str, input: impl AsRef<[u8]>) -> KcapiResult<Vec<u8>> {
     let hash = crate::md::KcapiHash::new(alg)?;
     hash.update(input)?;
     let output = hash.finalize()?;
@@ -425,11 +437,14 @@ pub fn digest(alg: &str, input: Vec<u8>) -> KcapiResult<Vec<u8>> {
 ///
 /// ```
 /// let key = vec![0x41u8; 16];
-/// let hmac = kcapi::md::keyed_digest("hmac(sha1)", key, "Hello, World!".as_bytes().to_vec())
+/// let hmac = kcapi::md::keyed_digest("hmac(sha1)", key.clone(), "Hello, World!".as_bytes().to_vec())
+///     .expect("Failed to calculate keyed message digest");
+///
+/// let hmac = kcapi::md::keyed_digest("hmac(sha1)", key, "Hello, World!".as_bytes())
 ///     .expect("Failed to calculate keyed message digest");
 /// ```
 ///
-pub fn keyed_digest(alg: &str, key: Vec<u8>, input: Vec<u8>) -> KcapiResult<Vec<u8>> {
+pub fn keyed_digest(alg: &str, key: Vec<u8>, input: impl AsRef<[u8]>) -> KcapiResult<Vec<u8>> {
     let mut hmac = crate::md::KcapiHash::new(alg)?;
     hmac.setkey(key)?;
     hmac.update(input)?;
@@ -452,9 +467,12 @@ pub fn keyed_digest(alg: &str, key: Vec<u8>, input: Vec<u8>) -> KcapiResult<Vec<
 ///
 /// ```
 /// let digest = kcapi::md::sha1("Hello, World!".as_bytes().to_vec());
+///
+/// let digest = kcapi::md::sha1("Hello, World!".as_bytes());
 /// ```
 ///
-pub fn sha1(input: Vec<u8>) -> KcapiResult<[u8; SHA1_DIGESTSIZE]> {
+pub fn sha1(input: impl AsRef<[u8]>) -> KcapiResult<[u8; SHA1_DIGESTSIZE]> {
+    let input = input.as_ref();
     let mut digest = [0u8; SHA1_DIGESTSIZE];
 
     let ret: kcapi_sys::ssize_t;
@@ -491,9 +509,12 @@ pub fn sha1(input: Vec<u8>) -> KcapiResult<[u8; SHA1_DIGESTSIZE]> {
 ///
 /// ```
 /// let digest = kcapi::md::sha224("Hello, World!".as_bytes().to_vec());
+///
+/// let digest = kcapi::md::sha224("Hello, World!".as_bytes());
 /// ```
 ///
-pub fn sha224(input: Vec<u8>) -> KcapiResult<[u8; SHA224_DIGESTSIZE]> {
+pub fn sha224(input: impl AsRef<[u8]>) -> KcapiResult<[u8; SHA224_DIGESTSIZE]> {
+    let input = input.as_ref();
     let mut digest = [0u8; SHA224_DIGESTSIZE];
 
     let ret: kcapi_sys::ssize_t;
@@ -530,9 +551,12 @@ pub fn sha224(input: Vec<u8>) -> KcapiResult<[u8; SHA224_DIGESTSIZE]> {
 ///
 /// ```
 /// let digest = kcapi::md::sha256("Hello, World!".as_bytes().to_vec());
+///
+/// let digest = kcapi::md::sha256("Hello, World!".as_bytes());
 /// ```
 ///
-pub fn sha256(input: Vec<u8>) -> KcapiResult<[u8; SHA256_DIGESTSIZE]> {
+pub fn sha256(input: impl AsRef<[u8]>) -> KcapiResult<[u8; SHA256_DIGESTSIZE]> {
+    let input = input.as_ref();
     let mut digest = [0u8; SHA256_DIGESTSIZE];
 
     let ret: kcapi_sys::ssize_t;
@@ -569,9 +593,12 @@ pub fn sha256(input: Vec<u8>) -> KcapiResult<[u8; SHA256_DIGESTSIZE]> {
 ///
 /// ```
 /// let digest = kcapi::md::sha384("Hello, World!".as_bytes().to_vec());
+///
+/// let digest = kcapi::md::sha384("Hello, World!".as_bytes());
 /// ```
 ///
-pub fn sha384(input: Vec<u8>) -> KcapiResult<[u8; SHA384_DIGESTSIZE]> {
+pub fn sha384(input: impl AsRef<[u8]>) -> KcapiResult<[u8; SHA384_DIGESTSIZE]> {
+    let input = input.as_ref();
     let mut digest = [0u8; SHA384_DIGESTSIZE];
 
     let ret: kcapi_sys::ssize_t;
@@ -608,9 +635,12 @@ pub fn sha384(input: Vec<u8>) -> KcapiResult<[u8; SHA384_DIGESTSIZE]> {
 ///
 /// ```
 /// let digest = kcapi::md::sha512("Hello, World!".as_bytes().to_vec());
+///
+/// let digest = kcapi::md::sha512("Hello, World!".as_bytes());
 /// ```
 ///
-pub fn sha512(input: Vec<u8>) -> KcapiResult<[u8; SHA512_DIGESTSIZE]> {
+pub fn sha512(input: impl AsRef<[u8]>) -> KcapiResult<[u8; SHA512_DIGESTSIZE]> {
+    let input = input.as_ref();
     let mut digest = [0u8; SHA512_DIGESTSIZE];
 
     let ret: kcapi_sys::ssize_t;
@@ -648,10 +678,17 @@ pub fn sha512(input: Vec<u8>) -> KcapiResult<[u8; SHA512_DIGESTSIZE]> {
 ///
 /// ```
 /// let key = vec![0xffu8; 16];
+/// let hmac = kcapi::md::hmac_sha1("Hello, World!".as_bytes(), &key);
+///
 /// let hmac = kcapi::md::hmac_sha1("Hello, World!".as_bytes().to_vec(), key);
 /// ```
 ///
-pub fn hmac_sha1(input: Vec<u8>, key: Vec<u8>) -> KcapiResult<[u8; SHA1_DIGESTSIZE]> {
+pub fn hmac_sha1(
+    input: impl AsRef<[u8]>,
+    key: impl AsRef<[u8]>,
+) -> KcapiResult<[u8; SHA1_DIGESTSIZE]> {
+    let input = input.as_ref();
+    let key = key.as_ref();
     let mut hmac = [0u8; SHA1_DIGESTSIZE];
 
     let ret: kcapi_sys::ssize_t;
@@ -691,10 +728,17 @@ pub fn hmac_sha1(input: Vec<u8>, key: Vec<u8>) -> KcapiResult<[u8; SHA1_DIGESTSI
 ///
 /// ```
 /// let key = vec![0xffu8; 16];
+/// let hmac = kcapi::md::hmac_sha224("Hello, World!".as_bytes(), &key);
+///
 /// let hmac = kcapi::md::hmac_sha224("Hello, World!".as_bytes().to_vec(), key);
 /// ```
 ///
-pub fn hmac_sha224(input: Vec<u8>, key: Vec<u8>) -> KcapiResult<[u8; SHA224_DIGESTSIZE]> {
+pub fn hmac_sha224(
+    input: impl AsRef<[u8]>,
+    key: impl AsRef<[u8]>,
+) -> KcapiResult<[u8; SHA224_DIGESTSIZE]> {
+    let input = input.as_ref();
+    let key = key.as_ref();
     let mut hmac = [0u8; SHA224_DIGESTSIZE];
 
     let ret: kcapi_sys::ssize_t;
@@ -734,10 +778,17 @@ pub fn hmac_sha224(input: Vec<u8>, key: Vec<u8>) -> KcapiResult<[u8; SHA224_DIGE
 ///
 /// ```
 /// let key = vec![0xffu8; 16];
+/// let hmac = kcapi::md::hmac_sha256("Hello, World!".as_bytes(), &key);
+///
 /// let hmac = kcapi::md::hmac_sha256("Hello, World!".as_bytes().to_vec(), key);
 /// ```
 ///
-pub fn hmac_sha256(input: Vec<u8>, key: Vec<u8>) -> KcapiResult<[u8; SHA256_DIGESTSIZE]> {
+pub fn hmac_sha256(
+    input: impl AsRef<[u8]>,
+    key: impl AsRef<[u8]>,
+) -> KcapiResult<[u8; SHA256_DIGESTSIZE]> {
+    let input = input.as_ref();
+    let key = key.as_ref();
     let mut hmac = [0u8; SHA256_DIGESTSIZE];
 
     let ret: kcapi_sys::ssize_t;
@@ -777,10 +828,17 @@ pub fn hmac_sha256(input: Vec<u8>, key: Vec<u8>) -> KcapiResult<[u8; SHA256_DIGE
 ///
 /// ```
 /// let key = vec![0xffu8; 16];
+/// let hmac = kcapi::md::hmac_sha384("Hello, World!".as_bytes(), &key);
+///
 /// let hmac = kcapi::md::hmac_sha384("Hello, World!".as_bytes().to_vec(), key);
 /// ```
 ///
-pub fn hmac_sha384(input: Vec<u8>, key: Vec<u8>) -> KcapiResult<[u8; SHA384_DIGESTSIZE]> {
+pub fn hmac_sha384(
+    input: impl AsRef<[u8]>,
+    key: impl AsRef<[u8]>,
+) -> KcapiResult<[u8; SHA384_DIGESTSIZE]> {
+    let input = input.as_ref();
+    let key = key.as_ref();
     let mut hmac = [0u8; SHA384_DIGESTSIZE];
 
     let ret: kcapi_sys::ssize_t;
@@ -820,10 +878,17 @@ pub fn hmac_sha384(input: Vec<u8>, key: Vec<u8>) -> KcapiResult<[u8; SHA384_DIGE
 ///
 /// ```
 /// let key = vec![0xffu8; 16];
+/// let hmac = kcapi::md::hmac_sha512("Hello, World!".as_bytes(), &key);
+///
 /// let hmac = kcapi::md::hmac_sha512("Hello, World!".as_bytes().to_vec(), key);
 /// ```
 ///
-pub fn hmac_sha512(input: Vec<u8>, key: Vec<u8>) -> KcapiResult<[u8; SHA512_DIGESTSIZE]> {
+pub fn hmac_sha512(
+    input: impl AsRef<[u8]>,
+    key: impl AsRef<[u8]>,
+) -> KcapiResult<[u8; SHA512_DIGESTSIZE]> {
+    let input = input.as_ref();
+    let key = key.as_ref();
     let mut hmac = [0u8; SHA512_DIGESTSIZE];
 
     let ret: kcapi_sys::ssize_t;


### PR DESCRIPTION
I've noticed that a number of functions take owned `Vec<u8>`s but could instead take slices. This has the benefit of not requiring allocations or allowing hashing just a part of the data (subslice).

This is a WIP but if it looks good I'll adjust the documentation and also the `setkey` call.