### PR TITLE
Make `KcapiHash` implement `Send`

### DIFF
--- a/src/md.rs
+++ b/src/md.rs
@@ -101,6 +101,8 @@ pub struct KcapiHash {
     pub digestsize: usize,
 }
 
+unsafe impl Send for KcapiHash {}
+
 impl KcapiHash {
     ///
     /// ## Initialize a `KcapiHash`

--- a/src/test/test_md.rs
+++ b/src/test/test_md.rs
@@ -327,4 +327,26 @@ mod tests {
         };
         assert_eq!(hmac, HMAC_EXP);
     }
+
+    #[test]
+    fn test_md_send() {
+        use crate::md::KcapiHash;
+        let hash = KcapiHash::new("sha1").expect("Failed to initialize hash handle");
+
+        hash.update("Hello, World".as_bytes().to_vec())
+            .expect("Failed to update hash with input buffer");
+
+        std::thread::spawn(move || {
+            let digest = hash.finalize().expect("Failed to finalize message digest");
+            assert_eq!(
+                digest,
+                &[
+                    144, 125, 20, 251, 58, 242, 176, 212, 241, 140, 45, 70, 171, 232, 174, 220,
+                    225, 115, 103, 189
+                ]
+            );
+        })
+        .join()
+        .unwrap();
+    }
 }


### PR DESCRIPTION
Based on the [discussion in kcapi repository][0] `kcapi_handle` is safe to send to other threads. Make `KcapiHash` implement `Send` and add a unit test that sends the object to other thread for finalization and check if the digest is correct.

[0]: https://github.com/smuellerDD/libkcapi/issues/158#issuecomment-1602230657