### PR TITLE
Do not derive `Clone` in structs containing `kcapi_handle`

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -315,7 +315,7 @@ pub enum KcapiAEADMode {
 /// `std::ffi::CString` type, the initialization will panic with the message
 /// `Failed to create CString`.
 ///
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct KcapiAEAD {
     handle: *mut kcapi_sys::kcapi_handle,
     iv: Vec<u8>,

--- a/src/akcipher.rs
+++ b/src/akcipher.rs
@@ -91,7 +91,7 @@ use crate::{KcapiError, KcapiResult, VMSplice, ACCESS_HEURISTIC, INIT_AIO};
 /// `std::ffi::CString` type, the initialization will panic with the message
 /// `Failed to create CString`.
 ///
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct KcapiAKCipher {
     handle: *mut kcapi_sys::kcapi_handle,
     pubkey: Vec<u8>,

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -79,7 +79,7 @@ use crate::{KcapiError, KcapiResult, INIT_AIO};
 /// };
 /// ```
 ///
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct KcapiKDF {
     digestsize: usize,
     handle: *mut kcapi_sys::kcapi_handle,

--- a/src/md.rs
+++ b/src/md.rs
@@ -92,7 +92,7 @@ pub const SHA512_DIGESTSIZE: usize = SHA512_BITSIZE / BITS_PER_BYTE;
 /// assert_eq!(hash.digestsize, SHA1_DIGESTSIZE);
 /// ```
 ///
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct KcapiHash {
     handle: *mut kcapi_sys::kcapi_handle,
     key: Vec<u8>,

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -77,7 +77,7 @@ use crate::{KcapiError, KcapiResult, INIT_AIO};
 /// };
 /// ```
 ///
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct KcapiRNG {
     handle: *mut kcapi_sys::kcapi_handle,
     pub algorithm: String,

--- a/src/skcipher.rs
+++ b/src/skcipher.rs
@@ -99,7 +99,7 @@ enum SKCipherMode {
 /// };
 /// ```
 ///
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct KcapiSKCipher {
     handle: *mut kcapi_sys::kcapi_handle,
     iv: Vec<u8>,


### PR DESCRIPTION
Default `Clone` implementation simply copies values. That makes two objects own the same backing `kcapi_handle` and after the first one is dropped the second one exhibits use-after-free.

Remove derivation of `Clone` from structs that contain `kcapi_handle` thus avoiding the problem.

This is a breaking change but the code that relied on structs implementing `Clone` is likely to be broken anyway.

Fixes https://github.com/puru1761/kcapi/issues/8